### PR TITLE
ResetCardScript

### DIFF
--- a/ResetCardScript
+++ b/ResetCardScript
@@ -1,0 +1,25 @@
+using UnityEngine;
+using System.Collections;
+using UnityEngine.UI;
+
+public class ResetCardScript : MonoBehaviour {
+
+
+	public InputField CardName;
+	public InputField CardNumber;
+	public Text nameC;
+	public Text numberC;
+	public GameObject CardAddLabel;
+
+	public void OnResetClick()
+	{
+		PlayerPrefs.DeleteKey("CreditName");		
+		PlayerPrefs.DeleteKey("CreditNumber");
+		nameC.text = "";
+		numberC.text = "";
+		CardName.interactable = true;
+		CardNumber.interactable = true;
+		CardAddLabel.SetActive (false);
+	}
+
+}


### PR DESCRIPTION
This script is attached to the button in the store menu that is meant to clear the current saved card name and card number. It deletes the player preference keys that point to the two string values.
